### PR TITLE
Create 404 link only if real file doesn't exists.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ runs:
               if [ true ==  ${{ inputs.useyarn }} ]; then yarn install --frozen-lockfile; else npm ci; fi
               if [ true ==  ${{ inputs.useyarn }} ]; then yarn build; else npm run build; fi
               cd dist
-              ln -s index.html 404.html
+              [ -f 404.html ] || ln -s index.html 404.html
               if [ "none" !=  ${{ inputs.cname }} ]; then echo '${{ inputs.cname }}' > CNAME; fi
               git config --global user.email "${{ inputs.gitemail }}"
               git config --global user.name "${{ inputs.gitname }}"


### PR DESCRIPTION
Added a check before the creation of the 404.html error page file only if another file doesn't exists. This prevent error when users adopt another solutions.